### PR TITLE
Embed Version Info into Build via Linker Flags

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -39,7 +39,7 @@ zopen_wharf()
 
 zopen_install()
 {
-  go install
+  go install -ldflags="-X 'main.Version=${GUM_VERSION}'"
 }
 
 zopen_clean()


### PR DESCRIPTION
Closes #10 

I would change around the $GUM_VERSION to pull from `gum -v`, but I'm not sure how it affects the bump workflow...