### PR TITLE
Set EBCDIC->ASCII Auto-Convert for `dev/tty` File Descriptor in Bubbletea

### DIFF
--- a/bubbletea-patches/tea.go.patch
+++ b/bubbletea-patches/tea.go.patch
@@ -1,0 +1,26 @@
+diff --git a/tea.go b/tea.go
+index f18cb87..c0df239 100644
+--- a/tea.go
++++ b/tea.go
+@@ -16,6 +16,7 @@ import (
+ 	"io"
+ 	"os"
+ 	"os/signal"
++	"runtime"
+ 	"runtime/debug"
+ 	"sync"
+ 	"sync/atomic"
+@@ -448,6 +449,13 @@ func (p *Program) Run() (Model, error) {
+ 		if err != nil {
+ 			return p.initialModel, err
+ 		}
++		if runtime.GOOS == "zos" {
++			// Set auto convert on /dev/tty fd for z/OS.
++			// /dev/tty is EBCDIC by default and will send EBCDIC
++			// key strokes to the program if not converted.
++			fd := int(f.Fd())
++			runtime.SetZosAutoConvOnFd(fd, 1047)
++		}
+ 		defer f.Close() //nolint:errcheck
+ 		p.input = f
+ 

--- a/buildenv
+++ b/buildenv
@@ -31,6 +31,9 @@ zopen_wharf()
 {
   cd ..
   git clone https://github.com/charmbracelet/bubbletea.git
+  cd ./bubbletea
+  git apply ../bubbletea-patches/tea.go.patch
+  cd ..
 
   go work init ./gum ./bubbletea
   wharf ./gum/...


### PR DESCRIPTION
fixes #9 

Description of the problem:
- Whenever gum received input via pipe instead of just standard terminal, it appeared to not receive any input from the keyboard
- It was still receiving input, just as EBCDIC instead of ASCII
  - We can see that in the `Run()` function of [bubbletea](https://github.com/charmbracelet/bubbletea)/tea.go that it defers to a helper function that opens `/dev/tty` if the standard input is not a terminal.
  - `/dev/tty` is always EBCDIC
  
Resolution:
- As a temporary fix we can add a GOOS check for z/OS and set the file descriptor to auto convert from EBCDIC to ASCII
- This solution would not be supported by wharf so we need to 'manually' patch it in.
- The auto-convert functionality is also specific to the Go on z/OS version of Go, so we will likely have to come up with another solution if we intend to upstream the fix.